### PR TITLE
Add ignore_pased and ignore_unnassigned to relate to tasks as well as connectors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,13 +12,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import sys
+
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
 from os import path
-import sys
 
 sys.path.insert(0, path.abspath("../"))
 sys.path.insert(0, path.abspath("../../"))
@@ -168,7 +169,9 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "kafka_connect_watcher", "ECS Compose-X Documentation", [author], 1)]
+man_pages = [
+    (master_doc, "kafka_connect_watcher", "ECS Compose-X Documentation", [author], 1)
+]
 
 
 # -- Options for Texinfo output ----------------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,4 +25,3 @@ With python
     source watcher/bin/activate
     pip install pip -U; pip install kafka-connect-watcher
     kafka-connect-watcher -c config.yaml
-

--- a/kafka_connect_watcher/aws_sns/__init__.py
+++ b/kafka_connect_watcher/aws_sns/__init__.py
@@ -54,7 +54,7 @@ class SnsChannel:
         for message_type, template_path in self._templates_definitions.items():
             if not path.exists(template_path):
                 raise FileNotFoundError(f"Template file not found: {template_path}")
-            with open(path.abspath(template_path), "r") as template_file:
+            with open(path.abspath(template_path)) as template_file:
                 self._messages_templates[message_type] = template_file.read()
 
     @property
@@ -144,7 +144,7 @@ class SnsChannel:
                     "role_session_name",
                     self.definition,
                     f"KafkaConnectWatcher{self.name}",
-                )
+                ),
             )
         else:
             return Session()

--- a/kafka_connect_watcher/config.py
+++ b/kafka_connect_watcher/config.py
@@ -42,7 +42,7 @@ class Config:
                 "You must specify either the configuration or the path to it."
             )
         if not configuration and config_file_path:
-            with open(path.abspath(config_file_path), "r") as config_fd:
+            with open(path.abspath(config_file_path)) as config_fd:
                 configuration = yaml.load(config_fd.read(), Loader=Loader)
         elif not config_file_path and not isinstance(configuration, (str, dict)):
             raise TypeError(
@@ -84,7 +84,7 @@ class Config:
                             f"{channel_name}.{sns_channel_name}"
                         ] = SnsChannel(sns_channel_name, sns_channel_definition)
                 else:
-                    LOG.warning("Channel {} is not supported.".format(channel_name))
+                    LOG.warning(f"Channel {channel_name} is not supported.")
 
     def __repr__(self):
         return json.dumps(self.original_config)

--- a/kafka_connect_watcher/connectors_eval.py
+++ b/kafka_connect_watcher/connectors_eval.py
@@ -68,8 +68,10 @@ def evaluate_connector_status(queue: Queue) -> None:
                         )
                     )
                 ):
+                    LOG.info(f'adding {connector.name} to running connectors')
                     running_connectors += 1
                 else:
+                    LOG.info(f'adding {connector.name} to fixing connectors')
                     connectors_to_fix.append(connector)
             elif connector.state == "PAUSED":
                 paused_connectors += 1

--- a/kafka_connect_watcher/connectors_eval.py
+++ b/kafka_connect_watcher/connectors_eval.py
@@ -45,6 +45,7 @@ def evaluate_connector_status(queue: Queue) -> None:
             ),
         }
         try:
+            LOG.info(f"Connector {connector.name}, {evaluation_rule.ignore_paused}")
             if connector.state in ["RUNNING"]:
                 if (
                     all([task.is_running() for task in connector.tasks])
@@ -77,6 +78,7 @@ def evaluate_connector_status(queue: Queue) -> None:
             elif connector.state == "UNASSIGNED":
                 unassigned_connectors += 1
                 if not evaluation_rule.ignore_unassigned:
+                    LOG.info('CYCLING CONNECTOR')
                     connector.cycle_connector()
             else:
                 connectors_to_fix.append(connector)

--- a/kafka_connect_watcher/connectors_eval.py
+++ b/kafka_connect_watcher/connectors_eval.py
@@ -45,7 +45,6 @@ def evaluate_connector_status(queue: Queue) -> None:
             ),
         }
         try:
-            LOG.info(f"Connector {connector.name}, {evaluation_rule.ignore_paused}")
             if connector.state in ["RUNNING"]:
                 if (
                     all([task.is_running() for task in connector.tasks])
@@ -68,10 +67,8 @@ def evaluate_connector_status(queue: Queue) -> None:
                         )
                     )
                 ):
-                    LOG.info(f'adding {connector.name} to running connectors')
                     running_connectors += 1
                 else:
-                    LOG.info(f'adding {connector.name} to fixing connectors')
                     connectors_to_fix.append(connector)
             elif connector.state == "PAUSED":
                 paused_connectors += 1
@@ -80,7 +77,6 @@ def evaluate_connector_status(queue: Queue) -> None:
             elif connector.state == "UNASSIGNED":
                 unassigned_connectors += 1
                 if not evaluation_rule.ignore_unassigned:
-                    LOG.info('CYCLING CONNECTOR')
                     connector.cycle_connector()
             else:
                 connectors_to_fix.append(connector)

--- a/kafka_connect_watcher/error_rules.py
+++ b/kafka_connect_watcher/error_rules.py
@@ -189,7 +189,7 @@ class AutoCorrectRule:
                 connector.pause()
             elif self.action == "cycle":
                 connector.cycle_connector()
-        
+
             if self.notify_targets:
                 for channel in self.notification_channels:
                     channel.send_error_notification(cluster, connector)

--- a/kafka_connect_watcher/watcher.py
+++ b/kafka_connect_watcher/watcher.py
@@ -97,7 +97,7 @@ class Watcher:
                 self.metrics.update(
                     {"connect_clusters_healthy": 0, "connect_clusters_unhealthy": 0}
                 )
-                LOG.debug("Watcher metrics: {}".format(self.metrics))
+                LOG.debug(f"Watcher metrics: {self.metrics}")
         except KeyboardInterrupt:
             self.keep_running = False
             LOG.debug("\rExited due to Keyboard interrupt")

--- a/tests/fixtures/configs/test_config.yaml
+++ b/tests/fixtures/configs/test_config.yaml
@@ -14,4 +14,3 @@ notification_channels:
   sns:
     main_topic:
       topic_arn: arn:aws:sns:eu-west-1:123456789:test-sns-topic
-

--- a/tests/fixtures/mock_config.py
+++ b/tests/fixtures/mock_config.py
@@ -32,3 +32,6 @@ class MockConnector:
         self.name = name
         self.state = state
         self.tasks = tasks
+
+    def cycle_connector(self):
+        pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,8 @@
-import pytest
-import yaml
 import json
 from os import path
+
+import pytest
+import yaml
 
 from kafka_connect_watcher.config import Config
 

--- a/tests/test_connectors_eval.py
+++ b/tests/test_connectors_eval.py
@@ -1,14 +1,16 @@
 from queue import Queue
-import pytest
 from unittest import Mock
 
+import pytest
+
+from kafka_connect_watcher.connectors_eval import evaluate_connector_status
+
 from .fixtures.mock_config import (
-    MockEvaluationRule,
     MockConnectCluster,
     MockConnector,
+    MockEvaluationRule,
     MockTask,
 )
-from kafka_connect_watcher.connectors_eval import evaluate_connector_status
 
 
 @pytest.mark.parametrize(
@@ -18,7 +20,7 @@ from kafka_connect_watcher.connectors_eval import evaluate_connector_status
         "len_connectors_to_fix",
         "ignore_unassigned",
         "ignore_paused",
-        "cycle_connector"
+        "cycle_connector",
     ],
     (
         (["FAILED"], ["RUNNING"], 1, False, False, False),
@@ -41,10 +43,12 @@ def test_evaluate_connector_status(
     len_connectors_to_fix,
     ignore_unassigned,
     ignore_paused,
-    cycle_connector
+    cycle_connector,
 ):
     connector_queue = Queue()
-    rule = MockEvaluationRule(ignore_paused=ignore_paused, ignore_unassigned=ignore_unassigned)
+    rule = MockEvaluationRule(
+        ignore_paused=ignore_paused, ignore_unassigned=ignore_unassigned
+    )
     connect = MockConnectCluster()
     connectors = []
     connectors_to_fix = []

--- a/tests/test_connectors_eval.py
+++ b/tests/test_connectors_eval.py
@@ -1,6 +1,8 @@
 from queue import Queue
 import pytest
-from fixtures.mock_config import (
+from unittest import Mock
+
+from .fixtures.mock_config import (
     MockEvaluationRule,
     MockConnectCluster,
     MockConnector,
@@ -13,33 +15,39 @@ from kafka_connect_watcher.connectors_eval import evaluate_connector_status
     [
         "connector_states",
         "task_states",
-        "expected_paused",
-        "expected_running",
-        "expected_unassigned",
         "len_connectors_to_fix",
+        "ignore_unassigned",
+        "ignore_paused",
+        "cycle_connector"
     ],
     (
-        (["FAILED"], ["RUNNING"], 0, 0, 0, 1),
-        (["RUNNING"], ["FAILED", "RUNNING"], 0, 0, 0, 1),
-        (["FAILED", "FAILED"], ["RUNNING"], 0, 0, 0, 2),
+        (["FAILED"], ["RUNNING"], 1, False, False, False),
+        (["RUNNING"], ["FAILED", "RUNNING"], 1, False, False, False),
+        (["RUNNING"], ["UNASSIGNED", "RUNNING"], 0, True, False, False),
+        (["RUNNING"], ["UNASSIGNED", "RUNNING"], 1, False, False, False),
+        (["RUNNING"], ["RUNNING", "PAUSED"], 0, False, True, False),
+        (["RUNNING"], ["PAUSED", "RUNNING"], 1, False, False, False),
+        (["PAUSED"], ["RUNNING"], 0, False, True, False),
+        (["PAUSED"], ["RUNNING"], 0, False, False, True),
+        (["UNASSIGNED"], ["RUNNING"], 0, True, False, False),
+        (["UNASSIGNED"], ["RUNNING"], 0, False, False, False),
+        (["FAILED", "FAILED"], ["RUNNING"], 2, False, False, False),
     ),
 )
 def test_evaluate_connector_status(
+    mocker,
     connector_states,
     task_states,
-    expected_paused,
-    expected_running,
-    expected_unassigned,
     len_connectors_to_fix,
+    ignore_unassigned,
+    ignore_paused,
+    cycle_connector
 ):
     connector_queue = Queue()
-    rule = MockEvaluationRule()
+    rule = MockEvaluationRule(ignore_paused=ignore_paused, ignore_unassigned=ignore_unassigned)
     connect = MockConnectCluster()
     connectors = []
     connectors_to_fix = []
-    paused_connectors: int = 0
-    unassigned_connectors: int = 0
-    running_connectors: int = 0
     for connector_state in connector_states:
         tasks = []
         for task_state in task_states:
@@ -50,8 +58,8 @@ def test_evaluate_connector_status(
             [rule, connect, connector, 0, 0, 0, connectors_to_fix],
             False,
         )
+    mock_cycle = mocker.patch("fixtures.mock_config.MockConnector.cycle_connector")
     evaluate_connector_status(connector_queue)
-    assert paused_connectors == expected_paused
-    assert running_connectors == expected_running
-    assert unassigned_connectors == expected_unassigned
     assert len(connectors_to_fix) == len_connectors_to_fix
+    if cycle_connector:
+        mock_cycle.assert_called_once_with()

--- a/tests/test_error_rules.py
+++ b/tests/test_error_rules.py
@@ -1,6 +1,8 @@
 import pytest
+
 from kafka_connect_watcher.error_rules import EvaluationRule
 from tests.fixtures.mock_config import MockClusterConfig
+
 
 @pytest.mark.parametrize(
     ["rule_definition", "connector_name", "expected"],


### PR DESCRIPTION
ignore_paused and ignore_unassigned to not filter down to the state of the tasks.

During a rebalance tasks can periodically be UNASSIGNED while the connector is still RUNNING, in this instance the watcher was adding the connector to connectors_to_fix even if ignore_unassigned was set to true.