### PR TITLE
Add Backoff Retry Logic 

### DIFF
--- a/kafka_connect_watcher/error_rules.py
+++ b/kafka_connect_watcher/error_rules.py
@@ -185,8 +185,8 @@ class AutoCorrectRule:
         use_backoff = "max_backoff" in self.config and "max_attempts" in self.config
 
         if use_backoff:
-            max_backoff = self.config["max_backoff"]
-            max_attempts = self.config["max_attempts"]
+            max_backoff = max(1, self.config["max_backoff"])
+            max_attempts = max(1, self.config["max_attempts"])
             backoff = initial_delay
             attempt = 0
 

--- a/kafka_connect_watcher/error_rules.py
+++ b/kafka_connect_watcher/error_rules.py
@@ -179,9 +179,50 @@ class AutoCorrectRule:
         return self._original_config
 
     def process(self, cluster: ConnectCluster, connector: Connector):
-        interval_delta = max(
+        initial_delay = max(
             5, int(get_duration_timedelta(self.wait_for_status).total_seconds())
         )
+        use_backoff = "max_backoff" in self.config and "max_attempts" in self.config
+
+        if use_backoff:
+            max_backoff = self.config["max_backoff"]
+            max_attempts = self.config["max_attempts"]
+            backoff = initial_delay
+            attempt = 0
+
+            LOG.info(
+                f"Backoff enabled: max_backoff={max_backoff}, max_attempts={max_attempts}"
+            )
+
+            while attempt < max_attempts:
+                status = connector.status
+                connector_state = status.get("connector", {}).get("state", "UNKNOWN")
+                task_states = [
+                    task.get("state", "UNKNOWN") for task in status.get("tasks", [])
+                ]
+
+                all_tasks_running = all(state == "RUNNING" for state in task_states)
+
+                if connector_state == "RUNNING" and all_tasks_running:
+                    LOG.info(
+                        f"{connector.name} and all its tasks have recovered. Skipping corrective action."
+                    )
+                    return
+
+                LOG.warning(
+                    f"{connector.name} not fully recovered (connector: {connector_state}, tasks: {task_states}). "
+                    f"Attempt {attempt + 1}/{max_attempts}. Waiting {backoff}s before re-checking..."
+                )
+                time.sleep(backoff)
+                backoff = min(max_backoff, backoff * 2)
+                attempt += 1
+        else:
+            LOG.info(
+                f"No backoff configured for connector {connector.name}. "
+                f"Applying corrective action '{self.action}' immediately."
+            )
+
+        # Apply the corrective action after backoff loop or immediately if no backoff
         try:
             if self.action == "restart":
                 connector.restart()
@@ -190,24 +231,30 @@ class AutoCorrectRule:
             elif self.action == "cycle":
                 connector.cycle_connector()
 
+            LOG.info(
+                f"Applied corrective action '{self.action}' to connector {connector.name}"
+            )
+
             if self.notify_targets:
                 for channel in self.notification_channels:
                     channel.send_error_notification(cluster, connector)
 
-            time.sleep(interval_delta)
-            print("Post action status", connector.name, connector.status)
+            time.sleep(initial_delay)
+            LOG.info(f"Post-action status for {connector.name}: {connector.status}")
+
         except Exception as error:
-            print(error)
+            LOG.exception(
+                f"Error applying corrective action to connector {connector.name}: {error}"
+            )
+
             if self.on_failure:
                 log_level_to_set = set_else_none("loglevel", self.on_failure)
                 connector_class = set_else_none(
                     "connector.class",
                     connector.config,
-                    set_else_none(
-                        "class",
-                        connector.config,
-                    ),
+                    set_else_none("class", connector.config),
                 )
+
                 if (
                     connector.state not in ["RUNNING", "PAUSED"]
                     and log_level_to_set

--- a/kafka_connect_watcher/watcher-config.spec.json
+++ b/kafka_connect_watcher/watcher-config.spec.json
@@ -148,6 +148,16 @@
           "type": "string",
           "description": "duration to wait before checking on the connector status post action"
         },
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of backoff retry attempts before the corrective action is applied."
+        },
+        "max_backoff": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum delay (in seconds) between backoff retries. Delay increases exponentially but is capped by this value."
+        },
         "notify": {
           "type": "array",
           "items": {

--- a/tests/test_connectors_eval.py
+++ b/tests/test_connectors_eval.py
@@ -1,5 +1,5 @@
 from queue import Queue
-from unittest import Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -62,7 +62,9 @@ def test_evaluate_connector_status(
             [rule, connect, connector, 0, 0, 0, connectors_to_fix],
             False,
         )
-    mock_cycle = mocker.patch("fixtures.mock_config.MockConnector.cycle_connector")
+    mock_cycle = mocker.patch(
+        "tests.fixtures.mock_config.MockConnector.cycle_connector"
+    )
     evaluate_connector_status(connector_queue)
     assert len(connectors_to_fix) == len_connectors_to_fix
     if cycle_connector:

--- a/tests/test_error_rules.py
+++ b/tests/test_error_rules.py
@@ -1,7 +1,13 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
 
-from kafka_connect_watcher.error_rules import EvaluationRule
-from tests.fixtures.mock_config import MockClusterConfig
+from kafka_connect_watcher.error_rules import AutoCorrectRule, EvaluationRule
+from tests.fixtures.mock_config import (
+    MockClusterConfig,
+    MockConnectCluster,
+    MockConnector,
+)
 
 
 @pytest.mark.parametrize(
@@ -16,3 +22,92 @@ def test_filter_out_connector(rule_definition, connector_name, expected):
     cluster_config = MockClusterConfig()
     rule = EvaluationRule(rule_definition, {})
     assert rule.filter_out_connector(connector_name, cluster_config) == expected
+
+
+@pytest.mark.parametrize(
+    "config, status_sequence, expected_action, expected_sleep_calls",
+    [
+        pytest.param(
+            {
+                "action": "restart",
+                "wait_for_status": "30s",
+                "max_backoff": 10,
+                "max_attempts": 3,
+            },
+            [
+                {"connector": {"state": "FAILED"}, "tasks": [{"state": "FAILED"}]},
+                {"connector": {"state": "RUNNING"}, "tasks": [{"state": "RUNNING"}]},
+            ],
+            "none",
+            [30],
+            id="recovers-on-second-attempt",
+        ),
+        pytest.param(
+            {
+                "action": "restart",
+                "wait_for_status": "30s",
+                "max_backoff": 50,
+                "max_attempts": 3,
+            },
+            [
+                {"connector": {"state": "FAILED"}, "tasks": [{"state": "FAILED"}]},
+                {"connector": {"state": "FAILED"}, "tasks": [{"state": "FAILED"}]},
+                {"connector": {"state": "FAILED"}, "tasks": [{"state": "FAILED"}]},
+            ],
+            "restart",
+            [30, 50],
+            id="fails-all-restart-called",
+        ),
+        pytest.param(
+            {
+                "action": "pause",
+                "wait_for_status": "30s",
+                "max_backoff": 5,
+                "max_attempts": 1,
+            },
+            [
+                {"connector": {"state": "FAILED"}, "tasks": [{"state": "FAILED"}]},
+            ],
+            "pause",
+            [],
+            id="single-attempt-pause",
+        ),
+    ],
+)
+@patch("time.sleep", return_value=None)
+def test_backoff_logic_with_mock_connector(
+    mock_sleep,
+    config,
+    status_sequence,
+    expected_action,
+    expected_sleep_calls,
+):
+    rule = AutoCorrectRule(config=config, watcher_config={})
+    connector = MockConnector()
+    connector.config = {"connector.class": "TestClass"}
+    connector.cluster.loggers = {"TestClass": True}
+
+    def status_side_effect():
+        yield from status_sequence
+        while True:
+            yield status_sequence[-1]
+
+    type(connector).status = PropertyMock(side_effect=status_side_effect())
+
+    connector.restart = MagicMock()
+    connector.pause = MagicMock()
+    connector.cycle_connector = MagicMock()
+
+    rule.process(cluster=MockConnectCluster(), connector=connector)
+
+    if expected_action == "restart":
+        connector.restart.assert_called_once()
+    elif expected_action == "pause":
+        connector.pause.assert_called_once()
+    else:
+        connector.restart.assert_not_called()
+        connector.pause.assert_not_called()
+
+    sleep_durations = [call.args[0] for call in mock_sleep.call_args_list]
+    backoff_durations = sleep_durations[: len(expected_sleep_calls)]
+    assert backoff_durations == expected_sleep_calls


### PR DESCRIPTION
This PR introduces **backoff retry behavior** to the `AutoCorrectRule.process` method. When a connector is in a failed state, the rule now retries status checks with an **exponential backoff** delay before applying any corrective action (`restart`, `pause`, etc.).

**New Config Options:**

The following optional config keys are now supported:

- `max_attempts` – number of retry attempts before triggering action (e.g., 3)
- `max_backoff` – maximum delay (in seconds) between retries (e.g., 10)

#### Why This Change?

Previously, the rule would immediately apply corrective action after a single sleep period. This could:

- Trigger unnecessary restarts/pause actions for transient issues
- Cause false alerts during connector rebalancing, where tasks momentarily appear as FAILED or UNASSIGNED
- Waste resources by restarting connectors that recover on their own

By allowing a **grace period with retries**, we reduce false positives and give failing connectors a chance to stabilize on their own.

#### How It Works

If both `max_attempts` and `max_backoff` are defined:

- The rule checks connector and task status
- If still failing, it waits using exponential backoff:  
  e.g. 5s → 10s → 10s (capped at `max_backoff`)
- Only after exhausting all attempts will the action be triggered

If these keys are **not set**, the rule behaves exactly as before (single wait, then act).

#### ✅ Example

```yaml
auto_correct_actions:
  - action: restart
    wait_for_status: 5s
    max_attempts: 3
    max_backoff: 10
```

This will retry up to 3 times (5s, 10s, 10s) before calling `restart`.